### PR TITLE
WIP Minor Fix to Add Node - EPSScene 

### DIFF
--- a/Source/EngineIDE/Core/Editor/Plugin/Scene/EPScene3D.cpp
+++ b/Source/EngineIDE/Core/Editor/Plugin/Scene/EPScene3D.cpp
@@ -1860,6 +1860,11 @@ void EPScene3D::HandleCreateGameAssetNode(StringHash eventType, VariantMap& even
             return;
         }
 
+        // Added to prevent crashing
+        unsigned int  FreeID = editorData_->GetEditorScene()->GetFreeNodeID(CreateMode::REPLICATED);
+
+        gameNode->SetID(FreeID);
+
         // Check if selected node
         if(editorSelection_->GetEditNode() != NULL)
         {


### PR DESCRIPTION
Minor Fix

1. Added a scene get free node ID and replace the game asset generated with it.

Problem
     Caused node overwrite and crash.
